### PR TITLE
Update overlap_perc and nr_cubes in fit_transform.

### DIFF
--- a/kmapper/kmapper.py
+++ b/kmapper/kmapper.py
@@ -241,6 +241,8 @@ class KeplerMapper(object):
         graph = {}
 
         self.clusterer = clusterer
+        self.nr_cubes = nr_cubes
+        self.overlap_perc = overlap_perc
 
         # If inverse image is not provided, we use the projection as the inverse image (suffer projection loss)
         if inverse_X is None:


### PR DESCRIPTION
Overlap percent and number of intervals were not being updated in fit_transform, so HTML output would show zero. This small 2-line PR fixes that. 

Before: 
![image](https://user-images.githubusercontent.com/290523/32863375-0880663c-ca3a-11e7-97c8-c4f9843e8698.png)
After:

![image](https://user-images.githubusercontent.com/290523/32863430-3d4f0076-ca3a-11e7-8f1f-e2967304db70.png)
