### PR TITLE
preset scaler incase is visualize is run without fit_transform first

### DIFF
--- a/kmapper/kmapper.py
+++ b/kmapper/kmapper.py
@@ -107,6 +107,7 @@ class KeplerMapper(object):
         self.overlap_perc = 0
         self.clusterer = False
         self.projection = None
+        self.scaler = None
 
     def fit_transform(self, X, projection="sum", scaler=preprocessing.MinMaxScaler(), distance_matrix=False):
         # Creates the projection/lens from X.


### PR DESCRIPTION
If you haven't run fit_transform first, then self.scaler isn't set yet.  

This presets `self.scaler` to `None` so fit_transform doesn't fail.