### PR TITLE
CI modifications to automatically build coverage report every commit

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,3 +1,2 @@
 [run]
 branch = True
-source = kmapper

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,9 +7,10 @@ python:
 
 install:
   - pip install .
+  - pip install pytest-cov
 
 script:
-  - pytest
+  - pytest --cov kmapper
 
 after_success:
   - bash <(curl -s https://codecov.io/bash)


### PR DESCRIPTION
These changes should make it so Travis-CI generates the code coverage report and uploads it to codecov.