### PR TITLE
Abstracted out the nerve builder to a separate class

### DIFF
--- a/kmapper/__init__.py
+++ b/kmapper/__init__.py
@@ -1,2 +1,3 @@
 from .kmapper import KeplerMapper
 from .kmapper import cluster
+from .nerve import GraphNerve

--- a/kmapper/kmapper.py
+++ b/kmapper/kmapper.py
@@ -243,12 +243,12 @@ class KeplerMapper(object):
         clusterer    	Scikit-learn API compatible clustering algorithm. Default: DBSCAN
         nr_cubes    	Int. The number of intervals/hypercubes to create.
         overlap_perc  Float. The percentage of overlap "between" the intervals/hypercubes.
+        nerve           Nerve builder implementing __call__(nodes) API.
         """
 
         start = datetime.now()
 
         nodes = defaultdict(list)
-        links = defaultdict(list)
         meta = defaultdict(list)
         graph = {}
 
@@ -333,7 +333,7 @@ class KeplerMapper(object):
                 if self.verbose > 1:
                     print("Cube_%s is empty.\n" % (i))
 
-        links, simplices = nerve(nodes, links)
+        links, simplices = nerve(nodes)
 
         graph["nodes"] = nodes
         graph["links"] = links
@@ -354,6 +354,7 @@ class KeplerMapper(object):
         return graph
 
     def _summary(self, graph, time):
+        # TODO: this summary is relevant to the type of Nerve being built.
         links = graph["links"]
         nodes = graph["nodes"]
         nr_links = sum(len(v) for k, v in links.items())

--- a/kmapper/kmapper.py
+++ b/kmapper/kmapper.py
@@ -10,6 +10,7 @@ import numpy as np
 from sklearn import cluster, preprocessing, manifold, decomposition
 from scipy.spatial import distance
 
+from .nerve import GraphNerve
 
 class Cover():
     """Helper class that defines the default covering scheme
@@ -116,6 +117,7 @@ class KeplerMapper(object):
         self.d = []
         self.projection = None
         self.scaler = None
+        self._create_links = None
 
     def fit_transform(self, X, projection="sum", scaler=preprocessing.MinMaxScaler(), distance_matrix=False):
         """Creates the projection/lens from X.
@@ -229,7 +231,7 @@ class KeplerMapper(object):
 
         return X
 
-    def map(self, projected_X, inverse_X=None, clusterer=cluster.DBSCAN(eps=0.5, min_samples=3), nr_cubes=10, overlap_perc=0.1):
+    def map(self, projected_X, inverse_X=None, clusterer=cluster.DBSCAN(eps=0.5, min_samples=3), nr_cubes=10, overlap_perc=0.1, nerve=GraphNerve()):
         """This maps the data to a simplicial complex. Returns a dictionary with nodes and links.
 
         Input:    projected_X. A Numpy array with the projection/lens.
@@ -332,11 +334,11 @@ class KeplerMapper(object):
                 if self.verbose > 1:
                     print("Cube_%s is empty.\n" % (i))
 
-        # TODO: create a `nerve builder` class that determines how nerve is built
-        links = self._create_links(nodes, links)
+        links, simplices = nerve(nodes, links)
 
         graph["nodes"] = nodes
         graph["links"] = links
+        graph["simplices"] = simplices
         graph["meta_data"] = {
             "projection": self.projection if self.projection else "custom",
             "nr_cubes": nr_cubes,
@@ -360,23 +362,6 @@ class KeplerMapper(object):
         print("\nCreated %s edges and %s nodes in %s." %
               (nr_links, len(nodes), time))
 
-    def _create_links(self, nodes, result=None):
-        """
-            Helper function to find edges of the overlapping clusters.
-
-            TODO: generalize to take nerve.
-        """
-        if result == None:
-            result = defaultdict(list)
-
-        # Create links when clusters from different hypercubes have members with the same sample id.
-        candidates = itertools.combinations(nodes.keys(), 2)
-        for candidate in candidates:
-            # if there are non-unique members in the union
-            if len(nodes[candidate[0]] + nodes[candidate[1]]) != len(set(nodes[candidate[0]] + nodes[candidate[1]])):
-                result[candidate[0]].append(candidate[1])
-
-        return result
 
     def visualize(self, complex, color_function="", path_html="mapper_visualization_output.html", title="My Data",
                   graph_link_distance=30, graph_gravity=0.1, graph_charge=-120, custom_tooltips=None, width_html=0,

--- a/kmapper/kmapper.py
+++ b/kmapper/kmapper.py
@@ -117,7 +117,6 @@ class KeplerMapper(object):
         self.d = []
         self.projection = None
         self.scaler = None
-        self._create_links = None
 
     def fit_transform(self, X, projection="sum", scaler=preprocessing.MinMaxScaler(), distance_matrix=False):
         """Creates the projection/lens from X.

--- a/kmapper/nerve.py
+++ b/kmapper/nerve.py
@@ -1,0 +1,42 @@
+import itertools
+from collections import defaultdict
+
+
+class Nerve:
+    """
+    Base class for implementations of a nerve finder to build a Mapper complex.
+
+    functions
+    ---------
+    __call__:     Return all simplices found by the nerve finder
+    """
+    def __init__(self):
+        pass
+
+    def __call__(self, nodes, links):
+        raise NotImplementedError()
+
+
+class GraphNerve(Nerve):
+    """
+    Creates the 1-skeleton of the Mapper complex.
+    """
+    def __call__(self, nodes, links):
+        """
+            Helper function to find edges of the overlapping clusters.
+
+            TODO: generalize to take nerve.
+        """
+        if links is None:
+            result = defaultdict(list)
+        else:
+            result = links
+
+        # Create links when clusters from different hypercubes have members with the same sample id.
+        candidates = itertools.combinations(nodes.keys(), 2)
+        for candidate in candidates:
+            # if there are non-unique members in the union
+            if len(nodes[candidate[0]] + nodes[candidate[1]]) != len(set(nodes[candidate[0]] + nodes[candidate[1]])):
+                result[candidate[0]].append(candidate[1])
+
+        return result, [[n] for n in nodes] + [[x] + result[x] for x in result]

--- a/kmapper/nerve.py
+++ b/kmapper/nerve.py
@@ -21,16 +21,20 @@ class GraphNerve(Nerve):
     """
     Creates the 1-skeleton of the Mapper complex.
     """
-    def __call__(self, nodes, links):
-        """
-            Helper function to find edges of the overlapping clusters.
+    def __call__(self, nodes):
+        """Helper function to find edges of the overlapping clusters.
 
-            TODO: generalize to take nerve.
+        Input
+        nodes:  A dictionary with entires {node id}:{list of ids in node}
+
+        Output
+        edges: A 1-skeleton of the nerve (intersecting  nodes)
+        simplicies: Complete list of simplices
+
+        TODO: generalize to take nerve.
         """
-        if links is None:
-            result = defaultdict(list)
-        else:
-            result = links
+
+        result = defaultdict(list)
 
         # Create links when clusters from different hypercubes have members with the same sample id.
         candidates = itertools.combinations(nodes.keys(), 2)
@@ -39,4 +43,5 @@ class GraphNerve(Nerve):
             if len(nodes[candidate[0]] + nodes[candidate[1]]) != len(set(nodes[candidate[0]] + nodes[candidate[1]])):
                 result[candidate[0]].append(candidate[1])
 
-        return result, [[n] for n in nodes] + [[x] + result[x] for x in result]
+        simplices = [[n] for n in nodes] + [[x] + result[x] for x in result]
+        return result, simplices

--- a/test/test_mapper.py
+++ b/test/test_mapper.py
@@ -4,7 +4,7 @@ import numpy as np
 from kmapper import KeplerMapper
 
 from kmapper.kmapper import Cover
-
+from kmapper import GraphNerve
 
 class TestVisualize():
     def test_visualize_standalone_same(self, tmpdir):
@@ -52,29 +52,26 @@ class TestVisualize():
 
 class TestLinker():
     def test_finds_a_link(self):
-        mapper = KeplerMapper()
-
+        nerve = GraphNerve()
         groups = {"a": [1,2,3,4], "b":[1,2,3,4]}
-        links = mapper._create_links(groups)
+        links, _ = nerve(groups)
 
         assert "a" in links or "b" in links
         assert links["a"] == ["b"] or links["b"] == ["a"]
 
     def test_no_link(self):
-        mapper = KeplerMapper()
-
+        nerve = GraphNerve()
         groups = {"a": [1,2,3,4], "b":[5,6,7]}
-        links = mapper._create_links(groups)
 
+        links, _ = nerve(groups)
         assert not links
 
     def test_pass_through_result(self):
-        mapper = KeplerMapper()
-
+        nerve = GraphNerve()
         groups = {"a": [1], "b":[2]}
 
         res = dict()
-        links = mapper._create_links(groups, res)
+        links, _ = nerve(groups)
 
         assert res == links
 


### PR DESCRIPTION
The previous method `_create_links` is now implemented by `.nerve.GraphNerve`, and will return a list of simplices as well as the neighbor graph needed for `links`.
By returning a full simplex list, alternative nerve methods that create the entire Cech complex of the refined pulled back cover will be easier to implement and integrate, and with them integration of homology (persistent or otherwise) will be easier.