### PR TITLE
add Jupyter Notebook support

### DIFF
--- a/kmapper/jupyter.py
+++ b/kmapper/jupyter.py
@@ -1,5 +1,6 @@
 import IPython
 
+# Here we set the custom CSS to override Jupyter's default
 CUSTOM_CSS = """<style>
     .container { width:100% !important; }
     .output_scroll {height: 800px !important;}
@@ -7,6 +8,22 @@ CUSTOM_CSS = """<style>
 IPython.core.display.display(IPython.core.display.HTML(CUSTOM_CSS))
 
 def display(path_html="mapper_visualization_output.html"):
+    """ Displays a html file inside a Jupyter Notebook output cell.
+    
+    Parameters
+    ----------
+    path_html : str
+        Path to html. Use file name for file inside current working 
+        directory. Use `file://` browser url-format for path to local file.
+        Use `https://` urls for externally hosted resources.
+
+    Notes
+    -----
+    Thanks to https://github.com/smartinsightsfromdata for the issue:
+    https://github.com/MLWave/kepler-mapper/issues/10
+
+    """
+
     iframe = '<iframe src=' + path_html \
             + ' width=100%% height=800 frameBorder="0"></iframe>'
     IPython.core.display.display(IPython.core.display.HTML(iframe))

--- a/kmapper/jupyter.py
+++ b/kmapper/jupyter.py
@@ -1,0 +1,12 @@
+import IPython
+
+CUSTOM_CSS = """<style>
+    .container { width:100% !important; }
+    .output_scroll {height: 800px !important;}
+    </style>"""
+IPython.core.display.display(IPython.core.display.HTML(CUSTOM_CSS))
+
+def display(path_html="mapper_visualization_output.html"):
+    iframe = '<iframe src=' + path_html \
+            + ' width=100%% height=800 frameBorder="0"></iframe>'
+    IPython.core.display.display(IPython.core.display.HTML(iframe))

--- a/notebooks/KeplerMapper usage in Jupyter Notebook.ipynb
+++ b/notebooks/KeplerMapper usage in Jupyter Notebook.ipynb
@@ -1,0 +1,126 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<style>\n",
+       "    .container { width:100% !important; }\n",
+       "    .output_scroll {height: 800px !important;}\n",
+       "    </style>"
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "import kmapper as km\n",
+    "from kmapper import jupyter # Creates custom CSS full-size Jupyter screen"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {
+    "collapsed": false,
+    "scrolled": false
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "..Projecting data using: [0, 1]\n",
+      "\n",
+      "..Scaling with: MinMaxScaler(copy=True, feature_range=(0, 1))\n",
+      "\n",
+      "Mapping on data shaped (5000, 2) using lens shaped (5000, 2)\n",
+      "\n",
+      "Creating 100 hypercubes.\n",
+      "\n",
+      "Created 89 edges and 58 nodes in 0:00:00.142366.\n",
+      "Wrote visualization to: make_circles_keplermapper_output.html\n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "<iframe src=http://mlwave.github.io/tda/word2vec-gender-bias.html width=100%% height=800 frameBorder=\"0\"></iframe>"
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "# Import the class\n",
+    "import kmapper as km\n",
+    "\n",
+    "# Some sample data\n",
+    "from sklearn import datasets\n",
+    "data, labels = datasets.make_circles(n_samples=5000, noise=0.03, factor=0.3)\n",
+    "\n",
+    "# Initialize\n",
+    "mapper = km.KeplerMapper(verbose=1)\n",
+    "\n",
+    "# Fit to and transform the data\n",
+    "projected_data = mapper.fit_transform(data, projection=[0,1]) # X-Y axis\n",
+    "\n",
+    "# Create dictionary called 'graph' with nodes, edges and meta-information\n",
+    "graph = mapper.map(projected_data, data, nr_cubes=10)\n",
+    "\n",
+    "# Visualize it\n",
+    "html = mapper.visualize(graph, path_html=\"make_circles_keplermapper_output.html\",\n",
+    "                 title=\"make_circles(n_samples=5000, noise=0.03, factor=0.3)\")\n",
+    "\n",
+    "# Inline display\n",
+    "# jupyter.display(path_html=\"http://mlwave.github.io/tda/word2vec-gender-bias.html\")\n",
+    "jupyter.display(path_html=\"make_circles_keplermapper_output.html\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 2",
+   "language": "python",
+   "name": "python2"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 2
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython2",
+   "version": "2.7.12"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 0
+}


### PR DESCRIPTION
This pull request adds Jupyter Notebook support.

```
from kmapper import jupyter
```
Inside a Jupyter notebook will change the jupyter CSS to accommodate inline display of KeplerMapper.

Display can be done by pointing to a local file (`path_html`) or an externally hosted KeplerMapper output.

```
jupyter.display(path_html="http://mlwave.github.io/tda/word2vec-gender-bias.html")
```

![jupyter display](https://i.imgur.com/5ZvSXgr.png)