### PR TITLE
Include the visualization html, js, and css in the installation

### DIFF
--- a/DEPLOY.md
+++ b/DEPLOY.md
@@ -1,0 +1,15 @@
+# Deployment procedures
+
+Helpful instructions can be found [here](https://github.com/fhamborg/news-please/wiki/PyPI---How-to-upload-a-new-version)
+
+
+1. Increment the version number in `setup.py`
+2. Add notes for the new version in `RELEASE.txt`
+3. Run the following commands to upload the new version to pypi
+
+```
+python setup.py sdist
+python setup.py sdist upload
+```
+
+4. Check [pypi.python.org](pypi.python.org) that the new version is present.

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,2 @@
+recursive-include kmapper/templates *
+recursive-include kmapper/static *

--- a/RELEASE.txt
+++ b/RELEASE.txt
@@ -70,3 +70,7 @@ v00009
     Separation of HTML, JS, CSS, and Python code
     New nerves and covers API
     Documentation site
+
+1.1.2
+		Bug fix, setup.py did not include static directory so installation visualizations did not work when installed from pypi.
+		Add Jupyter notebook support

--- a/kmapper/__init__.py
+++ b/kmapper/__init__.py
@@ -2,5 +2,7 @@ from .kmapper import KeplerMapper
 from .kmapper import cluster
 from .cover import Cover
 from .nerve import GraphNerve
+
+# Enable access to version number
 import pkg_resources
 __version__ = pkg_resources.get_distribution('kmapper').version

--- a/kmapper/__init__.py
+++ b/kmapper/__init__.py
@@ -1,4 +1,6 @@
 from .kmapper import KeplerMapper
 from .kmapper import cluster
-from .kmapper import Cover
-from .kmapper import GraphNerve
+from .cover import Cover
+from .nerve import GraphNerve
+import pkg_resources
+__version__ = pkg_resources.get_distribution('kmapper').version

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 from distutils.core import setup
 
 setup(name='kmapper',
-      version='1.1.1',
+      version='1.1.2',
       description='Python implementation of Mapper algorithm for Topological Data Analysis.',
       long_description="""
 This is a Python implementation of the TDA Mapper algorithm for visualization of high-dimensional data. For complete documentation, see https://MLWave.github.io/kepler-mapper.

--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,6 @@ KeplerMapper can make use of Scikit-Learn API compatible cluster and scaling alg
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
       ],
-      keywords='mapper, topology data analysis, algebraic topology, unsupervised learning'
-
-
+      keywords='mapper, topology data analysis, algebraic topology, unsupervised learning',
+      include_package_data=True
      )


### PR DESCRIPTION
Previously, the `static` and `templates` were not being included in the install.

This issue was brought to our attention by [Kunal Deore](https://twitter.com/kdeore2).