### PR TITLE
fix icon

### DIFF
--- a/kmapper/templates/base.html
+++ b/kmapper/templates/base.html
@@ -2,7 +2,6 @@
 <html>
 
 <head>
-  <div id="json_graph" data-graph='{{ json_graph }}' style="display:none"></div>
   <meta charset="utf-8">
   <meta name="generator" content="KeplerMapper">
   <title>{{ title }} | KeplerMapper</title>
@@ -14,6 +13,7 @@
 </head>
 
 <body id="display">
+  <div id="json_graph" data-graph='{{ json_graph }}' style="display:none"></div>
   <div id="header">
     <noscript><b>Requires JavaScript (d3.js) for visualizations</b></noscript>
     <h1>{{ title }}</h1>


### PR DESCRIPTION
move the json_graph div out of `<head>`, which fixes the rel icon. The rel icon wasn't rendering before because with the `<div>` in head, Chrome was pushing all `<head>` content down into the `<body>`, and rel tags don't work in the body.