### PR TITLE
extract min_cluster_size from hdbscan appropriately

### DIFF
--- a/kmapper/kmapper.py
+++ b/kmapper/kmapper.py
@@ -344,7 +344,10 @@ class KeplerMapper(object):
         # to adjust for the minimal number of samples inside an interval before
         # we consider clustering or skipping it.
         cluster_params = clusterer.get_params()
-        min_cluster_samples = cluster_params.get("n_clusters", 1)
+        
+        min_cluster_samples = cluster_params.get("n_clusters", None)
+        if min_cluster_samples is None:
+            min_cluster_samples = cluster_params.get("min_cluster_size", 1)
 
         if self.verbose > 1:
             print("Minimal points in hypercube before clustering: %d" %


### PR DESCRIPTION
HDBSCAN will balk if it is given fewer data points than `min_cluster_size`. This fixes that case.

It is possible that other clustering algorithms have an analogous minimum with a different name. Eventually, we should add most, or devise a work around.