### PR TITLE
Fix #120 color_function max bug from MinMaxScaler floating point issues

### DIFF
--- a/kmapper/visuals.py
+++ b/kmapper/visuals.py
@@ -127,6 +127,10 @@ def init_color_function(graph, color_function=None):
     # MinMax Scaling to be friendly to non-scaled input.
     scaler = preprocessing.MinMaxScaler()
     color_function = scaler.fit_transform(color_function).ravel()
+
+    # "Scaler might have floating point issues, 1.0000...0002". Force max and min
+    color_function[color_function > 1] = 1
+    color_function[color_function < 0] = 0
     return color_function
 
 

--- a/test/test_visuals.py
+++ b/test/test_visuals.py
@@ -104,10 +104,14 @@ class TestVisualHelpers:
         cf = np.array([6, 5, 4, 3, 2, 1])
         color_function = init_color_function(graph, cf)
 
-        np.testing.assert_almost_equal(min(color_function), 0)
-        np.testing.assert_almost_equal(
-            max(color_function), 1
-        ), "Scaler might have floating point issues, 1.0000...0002"
+        # np.testing.assert_almost_equal(min(color_function), 0)
+        # np.testing.assert_almost_equal(
+        #     max(color_function), 1
+        # ), "Scaler might have floating point issues, 1.0000...0002"
+
+        # build_histogram in visuals.py assumes/needs this
+        assert min(color_function) == 0
+        assert max(color_function) == 1
 
     def test_color_hist_matches_nodes(self):
         """ The histogram colors dont seem to match the node colors, this should confirm the colors will match and we need to look at the javascript instead.


### PR DESCRIPTION
Proposed solution for Issue #120 

visuals.py build_histogram assumes `data` (which takes color_function values) are all within [0,1]. However, color_function is scaled by MinMaxScaler to be in the range 0,1, but this is known to have floating point issues, e.g. max = 1.0000...0002. 