### PR TITLE
Corrected cubical cover computation

### DIFF
--- a/kmapper/cover.py
+++ b/kmapper/cover.py
@@ -7,6 +7,7 @@ except:
 
 import warnings
 from itertools import product
+
 import numpy as np
 
 # TODO: Incorporate @pablodecm's cover API.
@@ -74,7 +75,6 @@ class Cover:
     def __init__(self, n_cubes=10, perc_overlap=0.5, limits=None, verbose=0):
         self.centers_ = None
         self.radius_ = None
-        self.inset_ = None
         self.inner_range_ = None
         self.bounds_ = None
         self.di_ = None
@@ -183,17 +183,12 @@ class Cover:
         bounds = self._compute_bounds(indexless_data)
         ranges = bounds[1] - bounds[0]
 
-        # (n-1)/n |range|
-        inner_range = ((n_cubes - 1) / n_cubes) * ranges
-        inset = (ranges - inner_range) / 2
-
-        # |range| / (2n ( 1 - p))
-        with np.errstate(divide='ignore'):
-            radius = ranges / (2 * (n_cubes) * (1 - perc_overlap))
+        # |range| / (2 (n - (n-1)p)
+        radius = ranges / (2 * ((n_cubes) - (n_cubes - 1) * perc_overlap))
 
         # centers are fixed w.r.t perc_overlap
         zip_items = list(bounds)  # work around 2.7,3.4 weird behavior
-        zip_items.extend([n_cubes, inset])
+        zip_items.extend([n_cubes, radius])
         centers_per_dimension = [
             np.linspace(b + r, c - r, num=n) for b, c, n, r in zip(*zip_items)
         ]
@@ -201,8 +196,6 @@ class Cover:
 
         self.centers_ = centers
         self.radius_ = radius
-        self.inset_ = inset
-        self.inner_range_ = inner_range
         self.bounds_ = bounds
         self.di_ = di
 

--- a/test/test_coverer.py
+++ b/test/test_coverer.py
@@ -1,10 +1,10 @@
 from __future__ import division
-import pytest
+
 import numpy as np
+import pytest
 from sklearn import datasets, preprocessing
 
 from kmapper import KeplerMapper
-
 from kmapper.cover import Cover
 
 
@@ -61,16 +61,23 @@ class TestCoverBasic:
     def test_perc_overlap(self, CoverClass):
         """
         2 cubes with 50% overlap and a range of [0,1] should lead to two cubes with intervals:
-            [0, .75]
-            [.25, 1]
+            [0, 2/3]
+            [1/3, 1]
         """
 
-        data = np.array([[0, 0], [1, 0.25], [2, 0.5], [3, 0.75], [4, 1]])
+        # Due to rounding issues 1/3 exactly causes issues
+        data = np.array(
+            [[0, 0], [1, 1.0 / 3.0 + 10 ** -12], [2, 0.5], [3, 2.0 / 3.0], [4, 1]]
+        )
 
-        cover = Cover(n_cubes=2, perc_overlap=0.5)
+        cover = CoverClass(n_cubes=2, perc_overlap=0.5)
         cubes = cover.fit(data)
         cubes = list(cubes)
         entries = [cover.transform_single(data, cube) for cube in cubes]
+
+        assert cubes[0] == pytest.approx(1.0 / 3.0)
+        assert cubes[1] == pytest.approx(2.0 / 3.0)
+        assert cover.radius_[0] == pytest.approx(1.0 / 3.0)
 
         for i in (0, 1, 2, 3):
             assert data[i] in entries[0]
@@ -90,7 +97,7 @@ class TestCoverBasic:
         cover = CoverClass(n_cubes=2, limits=[[0, 1], [0, 1]])
         cover.fit(data)
         assert cover.find(np.array([0.2, 0.2])) == [0]
-        assert cover.find(np.array([0.6, 0.7])) == [0, 1, 2, 3]
+        assert cover.find(np.array([0.6, 0.5])) == [0, 1, 2, 3]
         assert cover.find(np.array([-1])) == []
 
     def test_complete_pipeline(self, CoverClass):
@@ -124,12 +131,12 @@ class TestCover:
     def test_radius_dist(self):
 
         test_cases = [
-            {"cubes": 1, "range": [0, 4], "overlap": 0.4, "radius": 10.0 / 3},
-            {"cubes": 1, "range": [0, 4], "overlap": 0.9, "radius": 20.0},
-            {"cubes": 2, "range": [-4, 4], "overlap": 0.5, "radius": 4.0},
-            {"cubes": 3, "range": [-4, 4], "overlap": 0.5, "radius": 2.666666666},
-            {"cubes": 10, "range": [-4, 4], "overlap": 0.5, "radius": 0.8},
-            {"cubes": 10, "range": [-4, 4], "overlap": 1.0, "radius": np.inf},
+            {"cubes": 1, "range": [0, 4], "overlap": 0.4, "radius": 2.0},
+            {"cubes": 1, "range": [0, 4], "overlap": 0.9, "radius": 2.0},
+            {"cubes": 2, "range": [-4, 4], "overlap": 0.5, "radius": 8.0 / 3.0},
+            {"cubes": 3, "range": [-4, 4], "overlap": 0.5, "radius": 2.0},
+            {"cubes": 10, "range": [-4, 4], "overlap": 0.5, "radius": 8.0 / 11.0},
+            {"cubes": 10, "range": [-4, 4], "overlap": 1.0, "radius": 4.0},
         ]
 
         for test_case in test_cases:
@@ -140,6 +147,7 @@ class TestCover:
             _ = cover.fit(data)
             assert cover.radius_[0] == pytest.approx(test_case["radius"])
 
+    @pytest.mark.skip("This test fails for correct implementations")
     def test_equal_entries(self):
         settings = {"cubes": 10, "overlap": 0.5}
 


### PR DESCRIPTION
The cubical cover computation is implemented incorrectly. It starts with the tests having the wrong expected behavior here:

https://github.com/scikit-tda/kepler-mapper/blob/05adb8f1c14d6f0951c280d83b695a971144dd3c/test/test_coverer.py#L61-L66

If you cover the interval `[0,1]` with 2 cubes with 50% overlape the cover you should get is `[0,2/3]` and `[1/3, 1]`. The cover `[0, .75]` `[0.25, 1]` has a percent overlap of `(0.75 - 0.25)/0.75 = 0.5/0.75 = 1/3`.  It is worth noting that this test actually generates the cover `[-0.25, 0.75]` `[0.25, 1.25]` which does have the correct overlap but has increased the range of the cover.

The source of the error is this line:
https://github.com/scikit-tda/kepler-mapper/blob/05adb8f1c14d6f0951c280d83b695a971144dd3c/kmapper/cover.py#L190-L192
There is an off-by-one error causing kmapper to count an intersection which doesn't exist. The computation should be `ranges / ( 2 * (n _cubes - (n_cubes - 1) * perc_overlap)`. 

There are other tests which enforce this incorrect behavior as well.
https://github.com/scikit-tda/kepler-mapper/blob/05adb8f1c14d6f0951c280d83b695a971144dd3c/test/test_coverer.py#L124-L133
This test in particular asserts that the cover should behave strangely. The first two test cases imply that a single element cover should be impacted by the overlap percentage chosen. While the last test is basically catching the fact that the current implementation has a division by 0. 

This pull request updates the tests to check for the correct behavior and updates the implementation to pass those tests. It also skips this test
https://github.com/scikit-tda/kepler-mapper/blob/05adb8f1c14d6f0951c280d83b695a971144dd3c/test/test_coverer.py#L143-L171
as what it is expecting doesn't always happen with a correct implementation.  I skip it instead of deleting the test outright as the core idea behind the test may be salvageable.